### PR TITLE
Change connection string in iot-pbm

### DIFF
--- a/test/ifem-heateqn/published/iot-pbm.py
+++ b/test/ifem-heateqn/published/iot-pbm.py
@@ -7,7 +7,7 @@ import IFEM_CoSTA as Ifem
 
 
 Problem = click.Path(file_okay=False, path_type=Path)
-cstr = os.getenv('COSTA_DDM_CSTR')
+cstr = os.getenv('COSTA_PBM_CSTR')
 
 
 @click.command()


### PR DESCRIPTION
With the previous version, I got a connection error when running 

https://github.com/keileg/Costa/blob/d5b9aa2ec36168c05766f98581ffae4d15e7dff4/test/ifem-heateqn/published/iot-trainer.py#L24